### PR TITLE
Force evaluate source geometry

### DIFF
--- a/Src/Projects/constraint_attachment/constraintAttachment.cxx
+++ b/Src/Projects/constraint_attachment/constraintAttachment.cxx
@@ -349,6 +349,7 @@ void CConstraintAttachment::SetupAllAnimationNodes()
 		mConstrainedRotation = AnimationNodeInCreate( 4, ReferenceGet( mGroupConstrain, 0 ), ANIMATIONNODE_TYPE_ROTATION );
 
 		DeformerBind( ReferenceGet(mGroupSource, 0) );
+		ReferenceGet(mGroupSource, 0)->ForceAlwaysEvaluate();
 	}
 	
 }


### PR DESCRIPTION
Force evaluate the source geometry so it does not need to be visible. This enables the constraint to be used in ribbon rig setups.